### PR TITLE
ci(publish): add temporary CI status gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,88 @@ permissions:
   id-token: write
 
 jobs:
+  gate-ci-status:
+    name: Gate CI status
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve publish target SHA
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TARGET_SHA=""
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+            git fetch --force --tags origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" || true
+            TARGET_SHA="$(git rev-list -n 1 "${GITHUB_REF_NAME}" 2>/dev/null || true)"
+          fi
+
+          if [[ -z "${TARGET_SHA}" ]]; then
+            TARGET_SHA="${GITHUB_SHA}"
+          fi
+
+          echo "sha=${TARGET_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "Publishing target SHA: ${TARGET_SHA}"
+
+      - name: Require successful CI on target SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          CI_WORKFLOW_ID: "232001328"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/${CI_WORKFLOW_ID}/runs?head_sha=${TARGET_SHA}&per_page=20" \
+            > /tmp/ci-runs.json
+
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          target_sha = os.environ["TARGET_SHA"]
+          workflow_id = os.environ["CI_WORKFLOW_ID"]
+
+          with open("/tmp/ci-runs.json", "r", encoding="utf-8") as handle:
+              payload = json.load(handle)
+
+          runs = payload.get("workflow_runs", [])
+          if not runs:
+              status = "missing"
+              print(f"BLOCKED: CI workflow on {target_sha} is {status}. Publish refused.")
+              print(f"Workflow: CI ({workflow_id})")
+              sys.exit(1)
+
+          run = runs[0]
+          run_status = run.get("status") or "unknown"
+          conclusion = run.get("conclusion")
+          status = conclusion if run_status == "completed" else run_status
+          run_url = run.get("html_url", "")
+
+          if status == "success":
+              print(f"CI workflow on {target_sha} is success. Publish allowed.")
+              print(f"Workflow: CI ({workflow_id})")
+              print(f"Run: {run_url}")
+              sys.exit(0)
+
+          print(f"BLOCKED: CI workflow on {target_sha} is {status}. Publish refused.")
+          print(f"Workflow: CI ({workflow_id})")
+          print(f"Run: {run_url}")
+          sys.exit(1)
+          PY
+
   build-and-publish:
+    needs: gate-ci-status
     if: github.repository == 'Admintepilora/tepilora-python'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
Temporary CI status gate in publish.yml. Refuses publish if CI workflow on the target SHA is not success.

## Status taxonomy (regola dell'orologio)
- Branch protection / rulesets: DEGRADED on current GitHub plan (HTTP 403 on private repos).
- Publish gate via workflow: OK (this PR).
- Coverage: blocks publish.yml triggered with CI red on target SHA.
- NOT covered: manual `twine upload` outside the workflow.

## Provenance gap discovered
- 0.4.1 was published via mirror `Admintepilora/tepilora-python` workflow (verified: private workflow run `22508388240` skipped, mirror run `22508394625` success, PyPI upload at 2026-02-27T23:52Z).
- 0.5.0 and 0.5.1 have no tag and no publish workflow run in either private or mirror, but exist on PyPI uploaded 2026-05-07T20:54Z / 20:57Z.
- Conclusion: 0.5.x publishes were performed manually outside the observed GitHub gateway. **This guard does not protect against direct `twine upload`.**
- Hardening required in Phase 3 (target-based propagate + PyPI publish only via gated workflow + revoke direct PyPI tokens for human users).

## Test evidence

### Red CI blocks (SDK private, CI failure)
```text
BLOCKED: CI workflow on dbebd4fbb88b897118222eae9a540cbaed7c609d is failure. Publish refused.
Workflow: CI (219790974)
Run: https://github.com/Admintepilora/TepiloraSDK/actions/runs/25521648002
EXIT_STATUS=1
```

### Green CI allows (MCP, CI success)
```text
CI workflow on 3707edc0fb79096370cdec99698749895ed7627e is success. Publish allowed.
Workflow: CI (233436009)
Run: https://github.com/Admintepilora/TepiloraMCP/actions/runs/25520875227
EXIT_STATUS=0
```

### Mirror missing SHA blocks
```text
BLOCKED: CI workflow on dbebd4fbb88b897118222eae9a540cbaed7c609d is missing. Publish refused.
Workflow: CI (232001328)
EXIT_STATUS=1
```

### Mirror red CI blocks
```text
BLOCKED: CI workflow on 8aeeea6732ea35d475c867ee7876e0e86a0507ab is failure. Publish refused.
Workflow: CI (232001328)
Run: https://github.com/Admintepilora/tepilora-python/actions/runs/22396553331
EXIT_STATUS=1
```

### Mirror green CI allows
```text
CI workflow on f50a97fa987aa081a82e35b8e8747b0bcb25a8c1 is success. Publish allowed.
Workflow: CI (232001328)
Run: https://github.com/Admintepilora/tepilora-python/actions/runs/22508394614
EXIT_STATUS=0
```

## Transition note
Patch di transizione fino a target-based propagate Phase 3 prende ownership del publish gate. Da rivedere insieme a `docs/PROPAGATE.md` target sdk/mcp/pypi/dashboard gates.
