### PR TITLE
chore(release): split publish jobs + pypi-prod environment (Phase 3.5.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           sys.exit(1)
           PY
 
-  build-and-publish:
+  build:
     needs: gate-ci-status
     if: github.repository == 'Admintepilora/tepilora-python'
     runs-on: ubuntu-latest
@@ -115,12 +115,43 @@ jobs:
         run: |
           python -m build
 
-      - name: Publish (TestPyPI)
-        if: startsWith(github.ref, 'refs/tags/test-v')
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/test-v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
-      - name: Publish (PyPI)
-        if: startsWith(github.ref, 'refs/tags/v')
+  publish-pypi:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/test-v')
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Phase 3.5.1 resolves Phase 3.0 open risk #4 and aligns the tepilora-python public mirror with the tepilora-mcp-python publish pattern to enforce Andrea policy B:

- TestPyPI rc -> automatic
- Real PyPI -> reviewer required

## Refactor

.github/workflows/publish.yml:

- build job renamed from build-and-publish: install/test/build plus upload dist artifact
- publish-testpypi job: needs build, test-v* only, no environment, OIDC publish to TestPyPI
- publish-pypi job: needs build, v* only with !test-v* guard, environment pypi-prod, OIDC publish to PyPI

## Policy mapping

| Tag | Job | Environment | Reviewer |
|---|---|---|---|
| test-v* | publish-testpypi | none | none automatic |
| v* excluding test-v* | publish-pypi | pypi-prod | required Andrea |

## Test plan

- [x] python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))" -> exit 0
- [x] git diff --check -> exit 0
- [ ] First test-v* publish post-merge runs publish-testpypi automatically
- [ ] First v* publish post-merge requires Andrea approval via pypi-prod environment

## Out of scope

- artifact hash verification + partial_publish wiring (Phase 3.5.3)
- release bridge propagation -> release_orchestrator (Phase 3.5.2)
- 5 oracle parity gate (Phase 3.6)

Only .github/workflows/publish.yml was modified. No Python source or tests changed.